### PR TITLE
Health service instances watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ serviceInstancesWatcher.watch("my-service", (WatchResult<ServiceInstances> insta
 }));
 ```
 
+##### Health Service Instances Watcher
+
+Same as Catalog Service Instances Watcher, but watches only healthy service instances.
+
+```java
+ExecutorService workerPool = Executors.newFixedThreadPool(10);
+EndpointWatcher<ServiceInstances> serviceInstancesWatcher = consulRecipes.healthServiceInstancesWatcher("my-services",
+            consulRecipes
+                .consulWatcher(workerPool)
+                .build())
+
+...
+
+serviceInstancesWatcher.watch("my-service", (WatchResult<ServiceInstances> instances) -> {
+    // proces instances for my-service
+}));
+```
 
 ### Datacenter reader
 

--- a/src/main/java/pl/allegro/tech/discovery/consul/recipes/ConsulRecipes.java
+++ b/src/main/java/pl/allegro/tech/discovery/consul/recipes/ConsulRecipes.java
@@ -14,6 +14,7 @@ import pl.allegro.tech.discovery.consul.recipes.watch.catalog.ServiceInstances;
 import pl.allegro.tech.discovery.consul.recipes.watch.catalog.ServiceInstancesWatcher;
 import pl.allegro.tech.discovery.consul.recipes.watch.catalog.Services;
 import pl.allegro.tech.discovery.consul.recipes.watch.catalog.ServicesWatcher;
+import pl.allegro.tech.discovery.consul.recipes.watch.health.HealthServiceInstancesWatcher;
 
 import java.net.URI;
 import java.time.Duration;
@@ -93,6 +94,10 @@ public class ConsulRecipes {
 
     public EndpointWatcher<ServiceInstances> catalogServiceInstancesWatcher(String serviceName, ConsulWatcher watcher) {
         return new ServiceInstancesWatcher(serviceName, watcher, jsonDeserializer);
+    }
+
+    public EndpointWatcher<ServiceInstances> healthServiceInstancesWatcher(String serviceName, ConsulWatcher watcher) {
+        return new HealthServiceInstancesWatcher(serviceName, watcher, jsonDeserializer);
     }
 
     public LeaderElector.Builder leaderElector(String serviceName) {

--- a/src/main/java/pl/allegro/tech/discovery/consul/recipes/json/JsonValueReader.java
+++ b/src/main/java/pl/allegro/tech/discovery/consul/recipes/json/JsonValueReader.java
@@ -1,0 +1,20 @@
+package pl.allegro.tech.discovery.consul.recipes.json;
+
+import java.util.Map;
+
+public class JsonValueReader {
+
+    @SuppressWarnings("unchecked")
+    public static <T> T requiredValue(Map serviceProps, String property, Class<T> clazz) {
+        Object value = serviceProps.get(property);
+        if (value == null) {
+            throw new JsonDecoder.JsonDecodeException(property + " property is missing in JSON. " +
+                    "This may indicate that there are incompatible changes in Consul API.");
+        }
+        if (!clazz.isAssignableFrom(value.getClass())) {
+            throw new JsonDecoder.JsonDecodeException("Invalid type of a property: " + property + ". Expected " + clazz + " got " + value.getClass()
+                    + " This may indicate that there are incompatible changes in Consul API.");
+        }
+        return (T) value;
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/discovery/consul/recipes/watch/health/HealthServiceInstancesWatcherIntTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/discovery/consul/recipes/watch/health/HealthServiceInstancesWatcherIntTest.groovy
@@ -1,0 +1,68 @@
+package pl.allegro.tech.discovery.consul.recipes.watch.health
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.ClassRule
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import pl.allegro.tech.discovery.consul.recipes.ConsulCluster
+import pl.allegro.tech.discovery.consul.recipes.ConsulRecipes
+import pl.allegro.tech.discovery.consul.recipes.json.JacksonJsonDeserializer
+import pl.allegro.tech.discovery.consul.recipes.watch.EndpointWatcher
+import pl.allegro.tech.discovery.consul.recipes.watch.catalog.ServiceInstances
+import pl.allegro.tech.discovery.consul.recipes.watch.catalog.Services
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.Executors
+
+class HealthServiceInstancesWatcherIntTest extends Specification {
+
+    static Logger logger = LoggerFactory.getLogger(HealthServiceInstancesWatcherIntTest)
+
+    @Shared
+    @ClassRule
+    ConsulCluster consulCluster = new ConsulCluster.Builder()
+            .withNode("dc1", "node1-dc1")
+            .build()
+
+    private ConsulRecipes recipes = ConsulRecipes.consulRecipes()
+            .withAgentUri(URI.create("http://localhost:${consulCluster.getHttpPort("dc1", "node1-dc1")}"))
+            .withJsonDeserializer(new JacksonJsonDeserializer(new ObjectMapper()))
+            .build()
+
+    private EndpointWatcher<Services> healthServiceInstancesWatcher = recipes.healthServiceInstancesWatcher("my-service",
+            recipes.consulWatcher(Executors.newFixedThreadPool(1))
+                    .withBackoff(100, 1000)
+                    .build())
+
+    def "should watch only healthy services"() {
+        given: "watcher on my-service details"
+        Deque<ServiceInstances> latestState = new ArrayDeque<>()
+        healthServiceInstancesWatcher.watch(
+                { latestState.push(it.body) },
+                { logger.error("Error while watching", it) })
+
+        expect: "watcher caught first empty state of service details"
+        new PollingConditions(timeout: 10).eventually {
+            !latestState.empty
+            latestState.head().instances.empty
+        }
+
+        when: "unhealthy service instance is registered"
+        consulCluster.registerUnhealthyServiceInstance("my-service", "dc1", "node1-dc1")
+
+        and: "healthy service instance is registered"
+        consulCluster.registerHealthyServiceInstance("my-service", "dc1", "node1-dc1", ["tag1", "tag2"])
+
+        then: "watcher caught new state with only healthy service instance"
+        new PollingConditions(timeout: 10).eventually {
+            latestState.head().instances.size() == 1
+            def instance = latestState.head().instances.first()
+            instance.serviceId != null
+            instance.serviceAddress == "localhost"
+            instance.servicePort == 1234
+            instance.serviceTags == ["tag1", "tag2"]
+        }
+    }
+}


### PR DESCRIPTION
Solves #9
Adds ability to watch healthy service instances.

I extracted `requiredValue` function to class otherwise I'd have to duplicate it.

The response from `/v1/catalog/service/` is different than `/v1/health/service/`

The `/v1/catalog/service/` response:
```
[
{
    "ID": "4fbf9ea0-c9a8-a0c5-2c84-6509c0da8639",
    "Node": "localhost",
    "Address": "127.0.0.1",
    "Datacenter": "dc1",
...
    "ServiceID": "sample_service_ip_port",
    "ServiceName": "sample_service",
    "ServiceTags": [
      "tag1"
    ],
    "ServiceAddress": "127.0.0.1",
...
    "ServicePort": 8080,
...
  }
]
```

The `/v1/health/service/` response:
```
[
{
    "Node": {
      ...
    },
    "Service": {
      "ID": "sample_service_ip_port",
      "Service": "sample_service",
      "Tags": [
        "tag1"
      ],
      "Address": "127.0.0.1",
      "Meta": null,
      "Port": 8080,
      ...
    },
    "Checks": [
      ...
    ]
  }
]
```
(I `...` non important part of the responses)

Because of the different responses, I had to create another `JsonDecoder`.

The test is not perfect. The `new PollingConditions` can caught registration of healthy service before unhealthy one, but otherwise I'd have to wait arbitrary time which I did not want to do.